### PR TITLE
Change API.AI references to their new name of Dialogflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# Api.ai - sample webhook implementation in Python
+# Dialogflow - sample webhook implementation in Python
 
-This is a really simple webhook implementation that gets Api.ai classification JSON (i.e. a JSON output of Api.ai /query endpoint) and returns a fulfillment response.
+This is a really simple webhook implementation that gets Dialogflow classification JSON (i.e. a JSON output of Dialogflow /query endpoint) and returns a fulfillment response.
 
-More info about Api.ai webhooks could be found here:
-[Api.ai Webhook](https://docs.api.ai/docs/webhook)
+More info about Dialogflow webhooks could be found here:
+[Dialogflow Webhook](https://dialogflow.com/docs/fulfillment)
 
 # Deploy to:
 [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 # What does the service do?
 It's a weather information fulfillment service that uses [Yahoo! Weather API](https://developer.yahoo.com/weather/).
-The services takes the `geo-city` parameter from the action, performs geolocation for the city and requests weather information from Yahoo! Weather public API. 
+The services takes the `geo-city` parameter from the action, performs geolocation for the city and requests weather information from Yahoo! Weather public API.
 
-The service packs the result in the Api.ai webhook-compatible response JSON and returns it to Api.ai.
-
+The service packs the result in the Dialogflow webhook-compatible response JSON and returns it to Dialogflow.

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
-  "name": "API.AI webhook demonstration",
-  "description": "API.AI webhook demonstration",
+  "name": "Dialogflow webhook demonstration",
+  "description": "Dialogflow webhook demonstration",
   "repository": "https://github.com/api-ai/apiai-weather-webhook-sample",
   "logo": "http://xvir.github.io/img/apiai.png",
-  "keywords": ["api.ai", "natural language"]
+  "keywords": ["api.ai", "dialogflow", "natural language"]
 }


### PR DESCRIPTION
This PR updates API.AI's name to Dialogflow, which is the new name for their service. I updated every reference to API.AI I could find, and included the new URL.

Not sure if you're planning on renaming the repo or how you'd like to handle the name change in that regard, but this should be a good starting point :)

All the best,

json